### PR TITLE
issue#4_complete

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,11 +13,11 @@ gem 'sqlite3'
 # Use Puma as the app server
 gem 'puma', '~> 3.7'
 # Use SCSS for stylesheets
-gem 'sass-rails', '~> 5.0'
+gem 'sass-rails', '~> 5.0.6'
 # Use Uglifier as compressor for JavaScript assets
 gem 'uglifier', '>= 1.3.0'
 # See https://github.com/rails/execjs#readme for more supported runtimes
-# gem 'therubyracer', platforms: :ruby
+gem 'therubyracer', platforms: :ruby
 
 # Use CoffeeScript for .coffee assets and views
 gem 'coffee-rails', '~> 4.2'
@@ -39,6 +39,14 @@ group :development, :test do
   # Adds support for Capybara system testing and selenium driver
   gem 'capybara', '~> 2.13'
   gem 'selenium-webdriver'
+  # 追加
+  gem 'hirb'         # モデルの出力結果を表形式で表示するGem
+  gem 'hirb-unicode' # 日本語などマルチバイト文字の出力時の出力結果のずれに対応
+  
+  gem 'pry-rails'  # rails console(もしくは、rails c)でirbの代わりにpryを使われる
+  gem 'pry-doc'    # methodを表示
+  gem 'pry-byebug' # デバッグを実施(Ruby 2.0以降で動作する)
+  gem 'pry-stack_explorer' # スタックをたどれる
 end
 
 group :development do
@@ -65,6 +73,15 @@ gem 'devise-i18n-views'
 
 # enum i18n対応
 gem 'enum_help'
+
+# bootstrap
+gem 'less-rails', git: 'https://github.com/MustafaZain/less-rails'
+gem 'twitter-bootstrap-rails' # Bootstrapの本体
+gem 'bootstrap-sass'
+gem 'autoprefixer-rails'
+
+# 日付・時刻のバリデーション
+gem 'validates_timeliness', '~> 4.0', '>= 4.0.2'
 
 
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,4 +1,14 @@
 GIT
+  remote: https://github.com/MustafaZain/less-rails
+  revision: 946213803a5b274260dad17526eb201230e4a761
+  specs:
+    less-rails (2.8.1)
+      actionpack (>= 4.0)
+      less (~> 2.6.0)
+      sprockets (> 2, < 4)
+      tilt
+
+GIT
   remote: https://github.com/plataformatec/devise.git
   revision: 71fc5b351a8e8473733b0ca29d60c06e43a0efe1
   specs:
@@ -52,8 +62,15 @@ GEM
     addressable (2.5.1)
       public_suffix (~> 2.0, >= 2.0.2)
     arel (8.0.0)
+    autoprefixer-rails (7.0.0)
+      execjs
     bcrypt (3.1.11)
     bindex (0.5.0)
+    binding_of_caller (0.7.2)
+      debug_inspector (>= 0.0.1)
+    bootstrap-sass (3.3.7)
+      autoprefixer-rails (>= 5.2.1)
+      sass (>= 3.3.4)
     builder (3.2.3)
     byebug (9.0.6)
     capybara (2.14.4)
@@ -65,6 +82,7 @@ GEM
       xpath (~> 2.0)
     childprocess (0.7.1)
       ffi (~> 1.0, >= 1.0.11)
+    coderay (1.1.1)
     coffee-rails (4.2.2)
       coffee-script (>= 2.2.0)
       railties (>= 4.0.0)
@@ -72,7 +90,9 @@ GEM
       coffee-script-source
       execjs
     coffee-script-source (1.12.2)
+    commonjs (0.2.7)
     concurrent-ruby (1.0.5)
+    debug_inspector (0.0.3)
     devise-i18n (1.2.0)
     devise-i18n-views (0.3.7)
     enum_help (0.0.17)
@@ -82,10 +102,17 @@ GEM
     ffi (1.9.18)
     globalid (0.4.0)
       activesupport (>= 4.2.0)
+    hirb (0.7.3)
+    hirb-unicode (0.0.5)
+      hirb (~> 0.5)
+      unicode-display_width (~> 0.1.1)
     i18n (0.8.6)
     jbuilder (2.7.0)
       activesupport (>= 4.2.0)
       multi_json (>= 1.2)
+    less (2.6.0)
+      commonjs (~> 0.2.7)
+    libv8 (3.16.14.19)
     listen (3.1.5)
       rb-fsevent (~> 0.9, >= 0.9.4)
       rb-inotify (~> 0.9, >= 0.9.7)
@@ -105,6 +132,21 @@ GEM
     nokogiri (1.8.0)
       mini_portile2 (~> 2.2.0)
     orm_adapter (0.5.0)
+    pry (0.10.4)
+      coderay (~> 1.1.0)
+      method_source (~> 0.8.1)
+      slop (~> 3.4)
+    pry-byebug (3.4.2)
+      byebug (~> 9.0)
+      pry (~> 0.10)
+    pry-doc (0.10.0)
+      pry (~> 0.9)
+      yard (~> 0.9)
+    pry-rails (0.3.6)
+      pry (>= 0.10.4)
+    pry-stack_explorer (0.4.9.2)
+      binding_of_caller (>= 0.7)
+      pry (>= 0.9.11)
     public_suffix (2.0.5)
     puma (3.9.1)
     rack (2.0.3)
@@ -137,6 +179,7 @@ GEM
     rb-fsevent (0.10.2)
     rb-inotify (0.9.10)
       ffi (>= 0.5.0, < 2)
+    ref (2.0.0)
     responders (2.4.0)
       actionpack (>= 4.2.0, < 5.3)
       railties (>= 4.2.0, < 5.3)
@@ -156,6 +199,7 @@ GEM
     selenium-webdriver (3.4.4)
       childprocess (~> 0.5)
       rubyzip (~> 1.0)
+    slop (3.6.0)
     spring (2.0.2)
       activesupport (>= 4.2)
     spring-watcher-listen (2.0.1)
@@ -169,16 +213,28 @@ GEM
       activesupport (>= 4.0)
       sprockets (>= 3.0.0)
     sqlite3 (1.3.13)
+    therubyracer (0.12.3)
+      libv8 (~> 3.16.14.15)
+      ref
     thor (0.19.4)
     thread_safe (0.3.6)
     tilt (2.0.8)
+    timeliness (0.3.8)
     turbolinks (5.0.1)
       turbolinks-source (~> 5)
     turbolinks-source (5.0.3)
+    twitter-bootstrap-rails (4.0.0)
+      actionpack (~> 5.0, >= 5.0.1)
+      execjs (~> 2.7)
+      less-rails (~> 2.8, >= 2.8.0)
+      railties (~> 5.0, >= 5.0.1)
     tzinfo (1.2.3)
       thread_safe (~> 0.1)
     uglifier (3.2.0)
       execjs (>= 0.3.0, < 3)
+    unicode-display_width (0.1.1)
+    validates_timeliness (4.0.2)
+      timeliness (~> 0.3.7)
     warden (1.2.7)
       rack (>= 1.0)
     web-console (3.5.1)
@@ -191,11 +247,14 @@ GEM
     websocket-extensions (0.1.2)
     xpath (2.1.0)
       nokogiri (~> 1.3)
+    yard (0.9.9)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
+  autoprefixer-rails
+  bootstrap-sass
   byebug
   capybara (~> 2.13)
   coffee-rails (~> 4.2)
@@ -203,19 +262,29 @@ DEPENDENCIES
   devise-i18n
   devise-i18n-views
   enum_help
+  hirb
+  hirb-unicode
   jbuilder (~> 2.5)
+  less-rails!
   listen (>= 3.0.5, < 3.2)
+  pry-byebug
+  pry-doc
+  pry-rails
+  pry-stack_explorer
   puma (~> 3.7)
   rails (~> 5.1.2)
-  sass-rails (~> 5.0)
+  sass-rails (~> 5.0.6)
   selenium-webdriver
   spring
   spring-watcher-listen (~> 2.0.0)
   sqlite3
+  therubyracer
   turbolinks (~> 5)
+  twitter-bootstrap-rails
   tzinfo-data
   uglifier (>= 1.3.0)
+  validates_timeliness (~> 4.0, >= 4.0.2)
   web-console (>= 3.3.0)
 
 BUNDLED WITH
-   1.15.1
+   1.15.3

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -13,3 +13,23 @@
 //= require rails-ujs
 //= require turbolinks
 //= require_tree .
+
+
+
+// ユーザートップページ　デジタル時計
+function set2fig(num) {
+   // 桁数が1桁だったら先頭に0を加えて2桁に調整する
+   var ret;
+   if( num < 10 ) { ret = "0" + num; }
+   else { ret = num; }
+   return ret;
+}
+function showClock2() {
+   var nowTime = new Date();
+   var nowHour = set2fig( nowTime.getHours() );
+   var nowMin  = set2fig( nowTime.getMinutes() );
+   var nowSec  = set2fig( nowTime.getSeconds() );
+   var msg = "現在時刻は、" + nowHour + ":" + nowMin + ":" + nowSec + " です。";
+   document.getElementById("RealtimeClockArea2").innerHTML = msg;
+}
+setInterval('showClock2()',1000);

--- a/app/assets/javascripts/attendances.coffee
+++ b/app/assets/javascripts/attendances.coffee
@@ -1,0 +1,3 @@
+# Place all the behaviors and hooks related to the matching controller here.
+# All this logic will automatically be available in application.js.
+# You can use CoffeeScript in this file: http://coffeescript.org/

--- a/app/assets/javascripts/bootstrap.js.coffee
+++ b/app/assets/javascripts/bootstrap.js.coffee
@@ -1,0 +1,3 @@
+jQuery ->
+  $("a[rel~=popover], .has-popover").popover()
+  $("a[rel~=tooltip], .has-tooltip").tooltip()

--- a/app/assets/stylesheets/application.css.scss
+++ b/app/assets/stylesheets/application.css.scss
@@ -13,3 +13,14 @@
  *= require_tree .
  *= require_self
  */
+@import "bootstrap-sprockets";
+@import "bootstrap";
+
+
+.top-menu {
+  text-align: center;
+}
+
+.login-btn {
+  margin: 100px;
+}

--- a/app/assets/stylesheets/attendances.scss
+++ b/app/assets/stylesheets/attendances.scss
@@ -1,0 +1,3 @@
+// Place all the styles related to the Attendances controller here.
+// They will automatically be included in application.css.
+// You can use Sass (SCSS) here: http://sass-lang.com/

--- a/app/assets/stylesheets/bootstrap_and_overrides.css.less
+++ b/app/assets/stylesheets/bootstrap_and_overrides.css.less
@@ -1,0 +1,21 @@
+@import "twitter/bootstrap/bootstrap";
+
+// Glyphicons are not required by default, uncomment the following lines to enable them.
+//@glyphiconsEotPath: font-url("glyphicons-halflings-regular.eot");
+//@glyphiconsEotPath_iefix: font-url("glyphicons-halflings-regular.eot?#iefix");
+//@glyphiconsWoffPath: font-url("glyphicons-halflings-regular.woff");
+//@glyphiconsTtfPath: font-url("glyphicons-halflings-regular.ttf");
+//@glyphiconsSvgPath: font-url("glyphicons-halflings-regular.svg#glyphicons_halflingsregular");
+//
+//@import "twitter/bootstrap/glyphicons.less";
+
+// Your custom LESS stylesheets goes here
+//
+// Since bootstrap was imported above you have access to its mixins which
+// you may use and inherit here
+//
+// If you'd like to override bootstrap's own variables, you can do so here as well
+// See http://twitter.github.com/bootstrap/customize.html#variables for their names and documentation
+//
+// Example:
+// @link-color: #ff0000;

--- a/app/controllers/attendances_controller.rb
+++ b/app/controllers/attendances_controller.rb
@@ -1,0 +1,89 @@
+class AttendancesController < ApplicationController
+  before_action :authenticate_admin!, only: [:index, :destroy, :approval]
+  before_action :authenticate_user!, only: [:create, :new, :edit, :show, :update, :start, :end, :request_status_change]
+
+  # admin 確認一覧用 v
+  def index
+    
+  end
+
+  # user 勤怠新規登録
+  def create
+    # @user = current_user.id
+    # @attendance = Attendance.new(attendance_params)
+    # @attendance.save
+    # redirect_to users_path(current_user.id), notice: '申請が完了しました'
+    @user = current_user.id
+    @attendance = Attendance.new(attendance_params)
+    if @attendance.save
+      redirect_to users_path(current_user.id), notice: '申請が完了しました'
+    else
+      flash.now[:alert] = "未入力の項目があります"
+      render :action => :new
+    end
+  end
+
+  # user 勤怠新規登録（直接入力） v
+  def new
+    @user = current_user.id
+    @attendance = Attendance.new
+  end
+
+  # user 勤怠情報修正 v
+  def edit
+    
+  end
+
+  # user 勤怠個別表示 v
+  def show
+    
+  end
+
+  # user 勤怠情報修正
+  def update
+    
+  end
+
+  # admin 勤怠情報削除
+  def destroy
+    
+  end
+
+  # admin 勤怠承認
+  def approval
+    
+  end
+
+  def start
+    @attendance = Attendance.new
+    @attendance.user_id = current_user.id
+    @attendance.start_at = Time.zone.now
+    @attendance.save
+    redirect_to users_path(current_user.id) and return
+  end
+
+  def end
+    @attendance = current_user.attendances.last
+    if @attendance.start_at.present?
+      now = Time.zone.now
+      @attendance.update(end_at: now)
+    end
+    redirect_to users_path(current_user.id) and return
+  end
+
+  def request_status_change
+    @attendance = current_user.attendances.last
+    if @attendance.request == false
+      @attendance.update(request: true)
+    end
+    redirect_to users_path(current_user.id) and return
+  end
+
+  private
+
+  def attendance_params
+    params.require(:attendance).permit(:start_at, :end_at, :user_id, :request, :approval, :edit)
+  end
+
+end
+

--- a/app/controllers/devise_admins/sessions_controller.rb
+++ b/app/controllers/devise_admins/sessions_controller.rb
@@ -24,7 +24,7 @@ class DeviseAdmins::SessionsController < Devise::SessionsController
   end
   # ログアウト後のリダイレクト先
   def after_sign_out_path_for(resource)
-    root_path
+    admin_session_path
   end
 
   # If you have extra params to permit, append them to the sanitizer.

--- a/app/controllers/devise_users/sessions_controller.rb
+++ b/app/controllers/devise_users/sessions_controller.rb
@@ -24,7 +24,7 @@ class DeviseUsers::SessionsController < Devise::SessionsController
   end
   # ログアウト後のリダイレクト先
   def after_sign_out_path_for(resource)
-    root_path
+    user_session_path
   end
 
   # If you have extra params to permit, append them to the sanitizer.

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,5 +1,8 @@
 class UsersController < ApplicationController
   before_action :authenticate_user!
-  def top    
+
+  def top
+    @attendance = current_user.attendances.last
   end
+
 end

--- a/app/helpers/attendances_helper.rb
+++ b/app/helpers/attendances_helper.rb
@@ -1,0 +1,2 @@
+module AttendancesHelper
+end

--- a/app/models/attendance.rb
+++ b/app/models/attendance.rb
@@ -1,0 +1,13 @@
+class Attendance < ApplicationRecord
+  belongs_to :user
+
+  # validates_datetime :start_at
+  # validates_datetime :end_at
+  # validates_datetime :end_at, after: :start_at
+
+  validates :start_at, presence: true, on: :create
+  validates :end_at, presence: true, on: :create
+
+  
+
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -4,6 +4,8 @@ class User < ApplicationRecord
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :trackable, :validatable
 
+  has_many :attendances
+
   enum gender: { 
     male: 0, 
     female: 1, 

--- a/app/views/attendances/new.html.erb
+++ b/app/views/attendances/new.html.erb
@@ -1,0 +1,13 @@
+<%= link_to "ユーザー専用トップページ", users_path(current_user.id) %><br />
+
+
+<h1>勤怠新規入力</h1>
+
+<%= form_for(@attendance, url: attendances_path) do |f| %>
+  <p>勤怠開始時間：<%= f.datetime_select :start_at, include_blank: true %></p>
+  <p>勤怠終了時間：<%= f.datetime_select :end_at, include_blank: true %></p>
+  <%= f.hidden_field :user_id, value: @user %>
+  <%= f.hidden_field :request, value: true %>
+  <%= f.submit "申請" %>
+<% end %>
+

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -9,8 +9,10 @@
   </head>
 
   <body>
-    <p class="notice"><%= notice %></p>
-    <p class="alert"><%= alert %></p>
-    <%= yield %>
+    <div class="container">
+      <p class="notice"><%= notice %></p>
+      <p class="alert"><%= alert %></p>
+      <%= yield %>
+    </div>
   </body>
 </html>

--- a/app/views/root/top.html.erb
+++ b/app/views/root/top.html.erb
@@ -1,5 +1,9 @@
 <h1>勤怠管理App トップページ</h1>
 
-<%= link_to "管理者ログイン", admin_session_path %>
+<div class="top-menu">
 
-<%= link_to "ユーザーログイン", user_session_path %>
+<%= link_to "管理者ログイン", admin_session_path, class: "btn btn-info btn-lg login-btn" %>
+
+<%= link_to "ユーザーログイン", user_session_path, class: "btn btn-info btn-lg login-btn" %>
+
+</div>

--- a/app/views/users/top.html.erb
+++ b/app/views/users/top.html.erb
@@ -1,5 +1,50 @@
 <h1>ユーザー専用トップページ</h1>
 
+<%= link_to "勤怠新規入力", new_attendance_path %><br />
+
 <%= link_to "パスワード変更", edit_user_registration_path %><br />
 
 <%= link_to "ログアウト", destroy_user_session_path, method: :delete %><br />
+
+<hr>
+
+<p id="RealtimeClockArea2"></p>
+
+<hr>
+
+<!-- 勤怠データが一つもない -->
+<% if @attendance.blank? %>
+  <p>本日の勤怠入力</p>
+  <p><%= "最初の勤怠を開始してください" %></p>
+  <%= button_to "勤怠を開始する", attendance_start_path, method: :post %>
+
+<!-- 勤怠データがある　＆　最後の勤怠データが今日以外　＆　未申請 -->
+<% elsif Date.parse(@attendance.start_at.to_s) != Date.today && @attendance.end_at.present? && @attendance.request == false %>
+  <p>申請されてない勤怠データがあります。申請をしてください。</p>
+  <p>勤怠開始時間：<%= @attendance.start_at %></p>
+  <p>勤怠終了時間：<%= @attendance.end_at %></p>
+  <%= button_to "申請", request_status_change_path(current_user.id), method: :patch %>
+
+<!-- 勤怠データがある　＆　最後の勤怠データが今日以外　＆　申請済 -->
+<% elsif Date.parse(@attendance.start_at.to_s) != Date.today && @attendance.request == true %>
+  <p>本日の勤怠入力</p>
+  <p><%= "勤怠を開始してください" %></p>
+  <%= button_to "勤怠を開始する", attendance_start_path(current_user.id), method: :post %>
+
+<!-- 勤怠データがある　＆　勤怠のデータが今日　＆　終了時間がnil -->
+<% elsif @attendance.start_at.present? && @attendance.end_at.nil? %>
+  <p>勤怠開始時間：<%= @attendance.start_at %></p>
+  <%= button_to "勤怠を終了する", attendance_end_path(current_user.id), method: :patch %>
+
+<!-- 勤怠データがある　＆　勤怠のデータが今日　＆　終了時間がある　＆　未申請 -->
+<% elsif @attendance.start_at.present? && @attendance.end_at.present? && @attendance.request == false %>
+  <p>勤怠開始時間：<%= @attendance.start_at %></p>
+  <p>勤怠終了時間：<%= @attendance.end_at %></p>
+  <p>本日の勤怠は終了しています。申請をしてください。</p>
+  <p>時間の変更がある場合には、勤怠一覧の編集メニューより修正ください。</p>
+  <%= button_to "申請", attendance_request_status_change_path, method: :patch %>
+
+ <!--  -->
+<% elsif %>
+  <p>本日もお疲れ様でした。</p>
+<% end %>

--- a/config/application.rb
+++ b/config/application.rb
@@ -13,6 +13,8 @@ module AttendanceApp
 
     config.i18n.default_locale = :ja
 
+    config.time_zone = 'Tokyo'
+
     # Settings in config/environments/* take precedence over those specified here.
     # Application configuration should go into files in config/initializers
     # -- all .rb files in that directory are automatically loaded.

--- a/config/initializers/time_formats.rb
+++ b/config/initializers/time_formats.rb
@@ -1,0 +1,5 @@
+Time::DATE_FORMATS[:default] = '%Y/%m/%d %H:%M:%S'
+Time::DATE_FORMATS[:datetime] = '%Y/%m/%d %H:%M:%S'
+Time::DATE_FORMATS[:date] = '%Y/%m/%d'
+Time::DATE_FORMATS[:time] = '%H:%M:%S'
+Date::DATE_FORMATS[:default] = '%Y/%m/%d'

--- a/config/locales/en.bootstrap.yml
+++ b/config/locales/en.bootstrap.yml
@@ -1,0 +1,23 @@
+# Sample localization file for English. Add more files in this directory for other locales.
+# See https://github.com/svenfuchs/rails-i18n/tree/master/rails%2Flocale for starting points.
+
+en:
+  breadcrumbs:
+    application:
+      root: "Index"
+    pages:
+      pages: "Pages"
+  helpers:
+    actions: "Actions"
+    links:
+      back: "Back"
+      cancel: "Cancel"
+      confirm: "Are you sure?"
+      destroy: "Delete"
+      new: "New"
+      edit: "Edit"
+    titles:
+      edit: "Edit %{model}"
+      save: "Save %{model}"
+      new: "New %{model}"
+      delete: "Delete %{model}"

--- a/config/locales/validates_timeliness.ja.yml
+++ b/config/locales/validates_timeliness.ja.yml
@@ -1,0 +1,16 @@
+ja:
+  errors:
+    messages:
+      invalid_date: "は、日付のフォーマットが間違っています"
+      invalid_time: "は、時間のフォーマットが間違っています"
+      invalid_datetime: "は、日時のフォーマットが間違っています"
+      is_at: "は、%{restriction} を指定してください"
+      before: "は、%{restriction} より小さい日時を指定してください"
+      on_or_before: "は、%{restriction} 以前の日時を指定してください"
+      after: "は、%{restriction} より大きい日時を指定してください"
+      on_or_after: "は、%{restriction} 以降の日時を指定してください"
+  validates_timeliness:
+    error_value_formats:
+      date: '%Y-%m-%d'
+      time: '%H:%M:%S'
+      datetime: '%Y-%m-%d %H:%M:%S'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,20 +3,26 @@ Rails.application.routes.draw do
 
   root 'root#top'
 
-  get 'admin', to: 'admins#top', as: 'admin'
+  # get 'admin', to: 'admins#top', as: 'admin'
+  authenticated :admin do
+    root 'admins#top', as: 'admin'
+  end
+
+  get 'users/:id', to: 'users#top', as: 'users'
+  # authenticated :user do
+  #   root 'users/:id', to: 'users#top', as: 'users'
+  # end
 
   devise_for :admins, path: 'devise_admins',
     controllers: {
       sessions: 'devise_admins/sessions',
       passwords: 'devise_admins/passwords'
     }
-    
+
   as :admin do
     get 'devise_admins/edit', to:'devise_admins/registrations#edit', as: 'edit_admin_registration'
     put 'devise_admins', to:'devise_admins/registrations#update', as: 'admin_registration'
   end
-
-  get 'users/:id', to: 'users#top', as: 'users'
 
   devise_for :users, path: 'devise_users',
     controllers: {
@@ -24,5 +30,10 @@ Rails.application.routes.draw do
       passwords: 'devise_users/passwords',    
       registrations: 'devise_users/registrations'
     }
+
+  resources :attendances
+  post 'attendances/start',                      to: 'attendances#start',                 as: :attendance_start
+  patch 'attendances/:id/end',                   to: 'attendances#end',                   as: :attendance_end
+  patch 'attendances/:id/request_status_change', to: 'attendances#request_status_change', as: :attendance_request_status_change
  
 end

--- a/db/migrate/20170731083940_create_attendances.rb
+++ b/db/migrate/20170731083940_create_attendances.rb
@@ -1,0 +1,14 @@
+class CreateAttendances < ActiveRecord::Migration[5.1]
+  def change
+    create_table :attendances do |t|
+      t.datetime :start_at
+      t.datetime :end_at
+      t.integer :user_id, null: false
+      t.boolean :request, null: false, default: false
+      t.boolean :approval, null: false, default: false
+      t.boolean :edit, null: false, default: false
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170727122754) do
+ActiveRecord::Schema.define(version: 20170731083940) do
 
   create_table "admins", force: :cascade do |t|
     t.string "email", default: "", null: false
@@ -27,6 +27,17 @@ ActiveRecord::Schema.define(version: 20170727122754) do
     t.datetime "updated_at", null: false
     t.index ["email"], name: "index_admins_on_email", unique: true
     t.index ["reset_password_token"], name: "index_admins_on_reset_password_token", unique: true
+  end
+
+  create_table "attendances", force: :cascade do |t|
+    t.datetime "start_at"
+    t.datetime "end_at"
+    t.integer "user_id", null: false
+    t.boolean "request", default: false, null: false
+    t.boolean "approval", default: false, null: false
+    t.boolean "edit", default: false, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
   end
 
   create_table "users", force: :cascade do |t|

--- a/test/controllers/attendances_controller_test.rb
+++ b/test/controllers/attendances_controller_test.rb
@@ -1,0 +1,7 @@
+require 'test_helper'
+
+class AttendancesControllerTest < ActionDispatch::IntegrationTest
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/test/fixtures/attendances.yml
+++ b/test/fixtures/attendances.yml
@@ -1,0 +1,15 @@
+# Read about fixtures at http://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  start: 2017-07-31 10:39:40
+  end: 2017-07-31 10:39:40
+  user_id: 1
+  approval: false
+  edit: false
+
+two:
+  start: 2017-07-31 10:39:40
+  end: 2017-07-31 10:39:40
+  user_id: 1
+  approval: false
+  edit: false

--- a/test/models/attendance_test.rb
+++ b/test/models/attendance_test.rb
@@ -1,0 +1,7 @@
+require 'test_helper'
+
+class AttendanceTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
一般ユーザーの勤怠入力画面を作成する
 勤怠入力画面において、リアルタイムに時刻表示が行われる(デジタル時計のような感じ)
 一般ユーザーはその日の勤怠を入力できる
 一般ユーザーの個人ページ(users/:id)において、「勤怠を開始する」ボタンを押下すると、その日の勤怠記録が開始される
 勤怠開始後は、勤怠終了まで勤怠開始ボタンを押下できない
 勤怠開始すると、その日の打刻した時間が表示される
 一般ユーザーの個人ページにおいて、「勤怠を終了する」ボタンを押下すると、その日の勤怠記録が終了する
 最終の勤怠の開始後でないと終了ボタンは押下できない
 勤怠の直接入力も可能(新規入力画面から行う)。その場合は、「開始時間」及び「終了時間」を両方とも入力することで登録が行える。片方でも入力がない場合にはエラーを出力する
 入力した内容を送信するボタンは「申請」という表記になるようにする